### PR TITLE
Support for 2022.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ pluginVersion = 0.1.5
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 203
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 213.5744.223
+platformVersion = 222.3345.118
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Updated the `pluginUntilBuild` to support 2022.2 (build 222).
I haven't done any tests, but it seems to work fine.